### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ homepage = "https://github.com/smol-rs/nb-connect"
 documentation = "https://docs.rs/nb-connect"
 keywords = ["TcpStream", "UnixStream", "socket2", "polling"]
 categories = ["asynchronous", "network-programming", "os"]
-readme = "README.md"
 
 [dependencies]
 socket2 = { version = "0.3.19", features = ["unix"] }


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.

