### PR TITLE
Bump to v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.0.4
+
+- Update `socket2` dependency to 0.4.
+
 # Version 1.0.3
 
 - Fix invalid assumption of `std::net::SocketAddrV{4,6}` layout.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nb-connect"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Jayce Fayne <jayce.fayne@mailbox.org>",


### PR DESCRIPTION
Changes:

- Update `socket2` dependency to 0.4.
