### PR TITLE
Deprecate in favor of socket2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.2.0
+
+- **This crate is now deprecated in favor of [socket2](https://crates.io/crates/socket2).**
+
 # Version 1.1.0
 
 - Increase MSRV to rustc 1.46.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "nb-connect"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.1.0"
+version = "1.2.0"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Jayce Fayne <jayce.fayne@mailbox.org>",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nb-connect
+# nb-connect (deprecated)
 
 [![Build](https://github.com/smol-rs/nb-connect/workflows/Build%20and%20test/badge.svg)](
 https://github.com/smol-rs/nb-connect/actions)
@@ -8,6 +8,8 @@ https://github.com/smol-rs/nb-connect)
 https://crates.io/crates/nb-connect)
 [![Documentation](https://docs.rs/nb-connect/badge.svg)](
 https://docs.rs/nb-connect)
+
+**This crate is now deprecated in favor of [socket2](https://crates.io/crates/socket2).**
 
 Non-blocking TCP or Unix connect.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,10 @@
 //! ```
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![deprecated(
+    since = "1.2.0",
+    note = "This crate is now deprecated in favor of [socket2](https://crates.io/crates/socket2)."
+)]
 
 use std::io;
 use std::net::{SocketAddr, TcpStream};


### PR DESCRIPTION
Based on the discussion in #5, deprecate this crate in favor of socket2.

cc @smol-rs/admins: Do you have any opposition? If not, I'll merge it 2 weeks later.